### PR TITLE
Remove odd usage of eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "emotion": "^9.2.4",
     "emotion-theming": "^9.2.4",
     "immer": "^1.3.1",
+    "lodash.get": "^4.4.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^5.0.3",

--- a/src/util/validate/index.ts
+++ b/src/util/validate/index.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
+import get from 'lodash.get'
 
 import * as validators from './validators'
-import get from 'lodash.get'
 
 type Validator = [number, Function]
 

--- a/src/util/validate/index.ts
+++ b/src/util/validate/index.ts
@@ -58,8 +58,8 @@ export const expectValue = options => (
   isValid?: Function,
   acceptFalsy = true
 ) => {
-  const resolved = `options${path}`
-  const value = eval(resolved)
+  const value = path === '' ? options : options[path.slice(1)]
+
   const valid =
     (typeof isValid === 'function' ? isValid(value) : typeof value === type) ||
     (!value && acceptFalsy)
@@ -67,7 +67,7 @@ export const expectValue = options => (
   if (!valid) {
     console.error('Invalid options!', options)
     throw new TypeError(
-      `Expected '${resolved}' to be typeof '${type}', received '${(value
+      `Expected 'options[${path.slice(1)}]' to be typeof '${type}', received '${(value
         ? value.constructor.name
         : typeof value
       ).toLowerCase()}'`

--- a/src/util/validate/index.ts
+++ b/src/util/validate/index.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 
 import * as validators from './validators'
+import get from 'lodash.get'
 
 type Validator = [number, Function]
 
@@ -58,7 +59,8 @@ export const expectValue = options => (
   isValid?: Function,
   acceptFalsy = true
 ) => {
-  const value = path === '' ? options : options[path.slice(1)]
+  const sliced = path.slice(1)
+  const value = path === '' ? options : get(options, sliced)
 
   const valid =
     (typeof isValid === 'function' ? isValid(value) : typeof value === type) ||
@@ -67,7 +69,7 @@ export const expectValue = options => (
   if (!valid) {
     console.error('Invalid options!', options)
     throw new TypeError(
-      `Expected 'options[${path.slice(1)}]' to be typeof '${type}', received '${(value
+      `Expected 'options[${sliced}]' to be typeof '${type}', received '${(value
         ? value.constructor.name
         : typeof value
       ).toLowerCase()}'`

--- a/src/util/validate/index.ts
+++ b/src/util/validate/index.ts
@@ -69,7 +69,7 @@ export const expectValue = options => (
   if (!valid) {
     console.error('Invalid options!', options)
     throw new TypeError(
-      `Expected 'options[${sliced}]' to be typeof '${type}', received '${(value
+      `Expected 'options${path}' to be typeof '${type}', received '${(value
         ? value.constructor.name
         : typeof value
       ).toLowerCase()}'`

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,6 +4104,11 @@ lodash.clone@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"


### PR DESCRIPTION
Removed an instance of eval so Crate can be used with CSP easier.