### PR TITLE
Expose types at root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { default as cdn } from './util/cdn'
 export { default } from './api'
+export { horizontal, vertical, default as Options } from './types/options'
+export { Message, Notification, State } from './types/store'
+export { default as Theme } from './types/theme'


### PR DESCRIPTION
If someone needs the types, they would currently need to do
```js
import { ... } from '@widgetbot/crate/dist/types/...';
```

Instead of
```js
import { ... } from '@widgetbot/crate';
```